### PR TITLE
BMO Program Picker Typo/UAT

### DIFF
--- a/src/app/_classes/program.ts
+++ b/src/app/_classes/program.ts
@@ -58,7 +58,7 @@ export class Program {
       }
     }
 
-    return daysSelected && sessionSelected;
+    return daySelected && sessionSelected;
   }
 
   get artsAreaList(): Array<string> {


### PR DESCRIPTION
Fix typo that made it block out programs that didn't actually meet on the same day(s)