### PR TITLE
BMO Parent Removal/UAT

### DIFF
--- a/src/app/components/application/personal-info/parent/parent.component.ts
+++ b/src/app/components/application/personal-info/parent/parent.component.ts
@@ -188,6 +188,8 @@ export class ParentComponent implements OnInit, OnChanges {
             this.parents.splice(pi, 1);
             if (this.student.billingParentId === parentContactId) {
               this.student.billingParentId = null;
+              // Set a new default billing parent if we can
+              this.setDefaultBillingParent();
             }
           } else {
             console.error('Could not delete parent: ' + parentContactId);


### PR DESCRIPTION
Try to set default billing parent after removing a parent, removing a parent doesn't seem to trigger the OnChanges call that would normally do this.